### PR TITLE
Hide badge level buttons

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -13,6 +13,9 @@
             $("input:radio[name='amount_extra'][value=250]").parents('.btn').append($('#canvas_print'));
             $('#canvas_print').on('click', function(e) { e.stopPropagation(); })
         }
+        if ($(".badge-type-selector")) {
+            $(".badge-type-selector").parents('.form-group').hide();
+        }
     });
 </script>
 


### PR DESCRIPTION
We don't want the badge level buttons anymore because we have a big list of kick-in buttons.