### PR TITLE
Add Supporter and Season Pass explanation popups

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -9,9 +9,14 @@
         }
         $("input:radio[name='amount_extra'][value=40]").parents('.btn').append($('#guitar_keychain'));
         $('#guitar_keychain').on('click', function(e) { e.stopPropagation(); })
-        if ($("input:radio[name='amount_extra'][value=250]")) {
+        if ($("input:radio[name='amount_extra'][value={{ c.SUPPORTER_LEVEL }}]")) {
             $("input:radio[name='amount_extra'][value=250]").parents('.btn').append($('#canvas_print'));
+            $("input:radio[name='amount_extra'][value=80]").parents('.btn').append($('#supporter_popup'));
+            $("input:radio[name='amount_extra'][value=160]").parents('.btn').append($('#season_popup'));
+
             $('#canvas_print').on('click', function(e) { e.stopPropagation(); })
+            $('#supporter_popup').on('click', function(e) { e.stopPropagation(); })
+            $('#season_popup').on('click', function(e) { e.stopPropagation(); })
         }
         if ($(".badge-type-selector")) {
             $(".badge-type-selector").parents('.form-group').hide();
@@ -54,4 +59,12 @@
 
 <div id="canvas_print">
     (<a href="http://magfest.org/sites/default/files/canvassample.png" target="_blank">art preview</a>)
+</div>
+
+<div id="supporter_popup">
+    ({% popup_link "../static_views/supporters.html" "What's this?" %})
+</div>
+
+<div id="season_popup">
+    ({% popup_link "../static_views/seasonPasses.html" "What's this?" %})
 </div>

--- a/magprime/templates/static_views/seasonPasses.html
+++ b/magprime/templates/static_views/seasonPasses.html
@@ -5,17 +5,17 @@
 </head>
 <body>
 
-<h3 align="center"> 2015 Supporter Season Passes </h3>
+<h3 align="center"> {{ c.EVENT_YEAR }} Supporter Season Passes </h3>
 
-When you buy a Season Supporter Pass, you get free badges to all events run by {{ c.EVENT_NAME }}.  This includes
+When you buy a Season Pass, you get free Attendee badges to all events run by {{ c.EVENT_NAME }}.  This includes
 <a target="_blank" href="http://magstock.net/">MAGStock</a>, 
-<a target="_blank" href="http://www.bitgengamerfest.com/">Bitgen</a>, and
-Game Over events held in 2015.
+<a target="_blank" href="http://classic.magfest.org/">MAGClassic</a>, and
+Game Over events held in {{ c.EVENT_YEAR }}. These badges do not include any extras, though you may kick in extra to upgrade them after you claim your badge.
 
 <br/> <br/>
 
 You'll be emailed before each event and given a chance to fill out a form to claim your complementary
-tickets.  These tickets are non-transferable; you're welcome to claim them for yourself but may not
+badges.  These badges are non-transferable; you're welcome to claim them for yourself but may not
 sell or transfer them to anyone else.
 
 </body>


### PR DESCRIPTION
This is in line with the art previews; most importantly, we had no way to see what a season pass was because the link had been removed from givingExtra.html.