### PR TITLE
Hide pre-reg help text from admin form

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -1,6 +1,7 @@
 <script type="text/javascript">
     $(function () {
         $('#extra_donation').insertAfter($.field('amount_extra').parents('.form-group'));
+        {% if c.PAGE_PATH != '/registration/form' %}
         $.field('amount_extra').parents('.form-group').append($('#tax_exempt'));
         if ($.field('shirt')) {
             $.field('shirt').parents('.form-group').append($('#tshirt_warning'));
@@ -21,6 +22,7 @@
         if ($(".badge-type-selector")) {
             $(".badge-type-selector").parents('.form-group').hide();
         }
+        {% endif %}
     });
 </script>
 
@@ -34,13 +36,15 @@
                 <span class="input-group-addon">.00</span>
             </div>
         </div>
+        {% if c.PAGE_PATH != '/registration/form' %}
         <p class="help-block col-sm-6 col-sm-offset-2">
             MAGFest inc is a 501(c)(3) charitable organization, and additional donations may be tax deductible.
             Your employer may also have a charitable donation matching program. E-mail contact@magfest.org for details.
         </p>
+        {% endif %}
     </div>
 </div>
-
+{% if c.PAGE_PATH != '/registration/form' %}
 <div id="tax_exempt">
     <div class="help-block col-sm-6 col-sm-offset-2">
         Badge tier upgrades may be partially tax deductible. E-mail contact@magfest.org for details.
@@ -68,3 +72,4 @@
 <div id="season_popup">
     ({% popup_link "../static_views/seasonPasses.html" "What's this?" %})
 </div>
+{% endif %}

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -9,15 +9,15 @@
             $('#tshirt_warning').hide();
         }
         $("input:radio[name='amount_extra'][value=40]").parents('.btn').append($('#guitar_keychain'));
-        $('#guitar_keychain').on('click', function(e) { e.stopPropagation(); })
+        $('#guitar_keychain').on('click', function(e) { e.stopPropagation(); });
         if ($("input:radio[name='amount_extra'][value={{ c.SUPPORTER_LEVEL }}]")) {
             $("input:radio[name='amount_extra'][value=250]").parents('.btn').append($('#canvas_print'));
             $("input:radio[name='amount_extra'][value=80]").parents('.btn').append($('#supporter_popup'));
             $("input:radio[name='amount_extra'][value=160]").parents('.btn').append($('#season_popup'));
 
-            $('#canvas_print').on('click', function(e) { e.stopPropagation(); })
-            $('#supporter_popup').on('click', function(e) { e.stopPropagation(); })
-            $('#season_popup').on('click', function(e) { e.stopPropagation(); })
+            $('#canvas_print').on('click', function(e) { e.stopPropagation(); });
+            $('#supporter_popup').on('click', function(e) { e.stopPropagation(); });
+            $('#season_popup').on('click', function(e) { e.stopPropagation(); });
         }
         if ($(".badge-type-selector")) {
             $(".badge-type-selector").parents('.form-group').hide();
@@ -37,39 +37,39 @@
             </div>
         </div>
         {% if c.PAGE_PATH != '/registration/form' %}
-        <p class="help-block col-sm-6 col-sm-offset-2">
-            MAGFest inc is a 501(c)(3) charitable organization, and additional donations may be tax deductible.
-            Your employer may also have a charitable donation matching program. E-mail contact@magfest.org for details.
-        </p>
+            <p class="help-block col-sm-6 col-sm-offset-2">
+                MAGFest inc is a 501(c)(3) charitable organization, and additional donations may be tax deductible.
+                Your employer may also have a charitable donation matching program. E-mail contact@magfest.org for details.
+            </p>
         {% endif %}
     </div>
 </div>
 {% if c.PAGE_PATH != '/registration/form' %}
-<div id="tax_exempt">
-    <div class="help-block col-sm-6 col-sm-offset-2">
-        Badge tier upgrades may be partially tax deductible. E-mail contact@magfest.org for details.
+    <div id="tax_exempt">
+        <div class="help-block col-sm-6 col-sm-offset-2">
+            Badge tier upgrades may be partially tax deductible. E-mail contact@magfest.org for details.
+        </div>
     </div>
-</div>
 
-<div id="tshirt_warning">
-    <div class="help-block col-sm-6 col-sm-offset-2">
-        <em>Slim fit sizes only available during online pre-order.</em>
+    <div id="tshirt_warning">
+        <div class="help-block col-sm-6 col-sm-offset-2">
+            <em>Slim fit sizes only available during online pre-order.</em>
+        </div>
     </div>
-</div>
 
-<div id="guitar_keychain">
-    (<a href="http://magfest.org/sites/default/files/keychainsample.png" target="_blank">art preview</a>)
-</div>
+    <span id="guitar_keychain">
+        ({% popup_link "http://magfest.org/sites/default/files/keychainsample.png" "Art Preview" %})
+    </span>
 
-<div id="canvas_print">
-    (<a href="http://magfest.org/sites/default/files/canvassample.png" target="_blank">art preview</a>)
-</div>
+    <span id="canvas_print">
+        ({% popup_link "http://magfest.org/sites/default/files/canvassample.png" "Art Preview" %})
+    </span>
 
-<div id="supporter_popup">
-    ({% popup_link "../static_views/supporters.html" "What's this?" %})
-</div>
+    <span id="supporter_popup">
+        ({% popup_link "../static_views/supporters.html" "What's included?" %})
+    </span>
 
-<div id="season_popup">
-    ({% popup_link "../static_views/seasonPasses.html" "What's this?" %})
-</div>
+    <span id="season_popup">
+        ({% popup_link "../static_views/seasonPasses.html" "What's included?" %})
+    </span>
 {% endif %}


### PR DESCRIPTION
Most of the MAGFest-specific changes to the reg form only matter for pre-reg forms, so they are not processed if on the admin page.

Fixes https://github.com/magfest/ubersystem/issues/1447.