### PR TITLE
Email vendors who registered after the deadline

### DIFF
--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -60,5 +60,8 @@ StopsEmail('MAGFest Staff Support', 'staff_support.txt',
 MarketplaceEmail('Your MAGFest Marketplace Application', 'marketplace_delay.txt',
                  lambda g: g.status == c.UNAPPROVED and g.registered < datetime(2015, 10, 29, tzinfo=c.EVENT_TIMEZONE))
 
+MarketplaceEmail('Your MAGFest Marketplace Application has been waitlisted', 'marketplace_auto_waitlisted.txt',
+                 lambda g: g.status == c.WAITLISTED and g.registered >= c.DEALER_REG_DEADLINE)
+
 StopsEmail('MAGFest Dept Checklist Introduction', 'dept_checklist_intro.txt',
            lambda a: a.is_single_dept_head and a.admin_account)

--- a/magprime/templates/emails/marketplace_auto_waitlisted.txt
+++ b/magprime/templates/emails/marketplace_auto_waitlisted.txt
@@ -1,0 +1,10 @@
+Hello {{ group.name }}!
+
+Thank you for your interest in MAGFest Marketplace. We've reviewed your application and, unfortunately,
+due to the high number of applicants this year, your marketplace application has been waitlisted.
+If a marketplace table slot becomes available, you will be notified and given the opportunity to accept
+that table. We'll be opening applications for the MAGFest 2017 Marketplace in summer 2017, so please try
+applying again in the future. Have a great evening!
+
+~ Danielle Pomfrey
+Marketplace Coordinator

--- a/magprime/templates/emails/marketplace_auto_waitlisted.txt
+++ b/magprime/templates/emails/marketplace_auto_waitlisted.txt
@@ -2,8 +2,14 @@ Hello {{ group.name }}!
 
 Thank you for your interest in MAGFest Marketplace. We've reviewed your application and, unfortunately,
 due to the high number of applicants this year, your marketplace application has been waitlisted.
+
 If a marketplace table slot becomes available, you will be notified and given the opportunity to accept
-that table. We'll be opening applications for the MAGFest 2017 Marketplace in summer 2017, so please try
+that table. 
+
+We also apologize because we were hoping to get this information out to applicants by Nov 8, 2015, 
+but due to a technical configuration error, this email was not sent until now.
+
+We'll be opening applications for the MAGFest 2017 Marketplace in summer 2017, so please try
 applying again in the future. Have a great evening!
 
 ~ Danielle Pomfrey


### PR DESCRIPTION
WIP, haven' tested this but I wanted to make sure this is what the intention was.
they will get an auto-waitlist email.

meant to get to this last week but got held up, here it is.

```c.DEALER_REG_DEADLINE``` is  ```'2015-08-02 03'```

Only question I need to answer is: is it possible for someone to
1) have registered after the cutoff date 
2) be waitlisted
3) shouldn't get this email

I think the answer is no, but I might check into it first.