### PR TITLE
Shirt size email

### DIFF
--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -76,7 +76,6 @@ AutomatedEmail(Attendee, 'Last Chance for MAGFest 2016 bonus swag!', 'attendee_s
 # who kicked in at the shirt level or above).	Should not be sent after the t-shirt
 # size deadline (a new deadline not yet recorded in uber).
 AutomatedEmail(Attendee, 'MAGFest 2016 t-shirt size confirmation', 'confirm_shirt_size.html',
-				lambda a: before(datetime(2016, 1, 16, tzinfo=c.EVENT_TIMEZONE) and
-						days_after(3, a.registered) and
-						a.gets_shirt))
-						
+               lambda a: before(datetime(2016, 1, 16, tzinfo=c.EVENT_TIMEZONE) and
+                         days_after(3, a.registered) and
+                         a.gets_shirt))

--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -77,4 +77,5 @@ AutomatedEmail(Attendee, 'Last Chance for MAGFest 2016 bonus swag!', 'attendee_s
 // size deadline (a new deadline not yet recorded in uber).					 
 AutomatedEmail(Attendee, 'MAGFest 2016 t-shirt size confirmation', 'confirm_shirt_size.html',
 				lambda a:  before(datetime(2016, 1, 16, tzinfo=c.EVENT_TIMEZONE) and
-				           false)// HALP!
+						   days_after(3, a.registered) and
+				           a.gets_shirt)

--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -71,3 +71,10 @@ AutomatedEmail(Attendee, 'Last Chance for MAGFest 2016 bonus swag!', 'attendee_s
                          (a.paid == c.HAS_PAID or a.paid == c.NEED_NOT_PAY or (a.group and a.group.amount_paid)) and
                          days_after(3, a.registered) and
                          days_before(14, c.SUPPORTER_DEADLINE))
+
+//Send to any attendee who will be receiving a t-shirt (staff, volunteers, anyone
+// who kicked in at the shirt level or above).	Should not be sent after the t-shirt
+// size deadline (a new deadline not yet recorded in uber).					 
+AutomatedEmail(Attendee, 'MAGFest 2016 t-shirt size confirmation', 'confirm_shirt_size.html',
+				lambda a:  before(datetime(2016, 1, 16, tzinfo=c.EVENT_TIMEZONE) and
+				           false)// HALP!

--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -76,7 +76,7 @@ AutomatedEmail(Attendee, 'Last Chance for MAGFest 2016 bonus swag!', 'attendee_s
 # who kicked in at the shirt level or above).	Should not be sent after the t-shirt
 # size deadline (a new deadline not yet recorded in uber).
 AutomatedEmail(Attendee, 'MAGFest 2016 t-shirt size confirmation', 'confirm_shirt_size.html',
-				lambda a:  before(datetime(2016, 1, 16, tzinfo=c.EVENT_TIMEZONE) and
+				lambda a: before(datetime(2016, 1, 16, tzinfo=c.EVENT_TIMEZONE) and
 						days_after(3, a.registered) and
-						a.gets_shirt)
+						a.gets_shirt))
 						

--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -72,10 +72,11 @@ AutomatedEmail(Attendee, 'Last Chance for MAGFest 2016 bonus swag!', 'attendee_s
                          days_after(3, a.registered) and
                          days_before(14, c.SUPPORTER_DEADLINE))
 
-#Send to any attendee who will be receiving a t-shirt (staff, volunteers, anyone
+# Send to any attendee who will be receiving a t-shirt (staff, volunteers, anyone
 # who kicked in at the shirt level or above).	Should not be sent after the t-shirt
-# size deadline (a new deadline not yet recorded in uber).					 
+# size deadline (a new deadline not yet recorded in uber).
 AutomatedEmail(Attendee, 'MAGFest 2016 t-shirt size confirmation', 'confirm_shirt_size.html',
 				lambda a:  before(datetime(2016, 1, 16, tzinfo=c.EVENT_TIMEZONE) and
-						   days_after(3, a.registered) and
-				           a.gets_shirt)
+						days_after(3, a.registered) and
+						a.gets_shirt)
+						

--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -72,9 +72,9 @@ AutomatedEmail(Attendee, 'Last Chance for MAGFest 2016 bonus swag!', 'attendee_s
                          days_after(3, a.registered) and
                          days_before(14, c.SUPPORTER_DEADLINE))
 
-//Send to any attendee who will be receiving a t-shirt (staff, volunteers, anyone
-// who kicked in at the shirt level or above).	Should not be sent after the t-shirt
-// size deadline (a new deadline not yet recorded in uber).					 
+#Send to any attendee who will be receiving a t-shirt (staff, volunteers, anyone
+# who kicked in at the shirt level or above).	Should not be sent after the t-shirt
+# size deadline (a new deadline not yet recorded in uber).					 
 AutomatedEmail(Attendee, 'MAGFest 2016 t-shirt size confirmation', 'confirm_shirt_size.html',
 				lambda a:  before(datetime(2016, 1, 16, tzinfo=c.EVENT_TIMEZONE) and
 						   days_after(3, a.registered) and

--- a/magprime/templates/emails/confirm_shirt_size.html
+++ b/magprime/templates/emails/confirm_shirt_size.html
@@ -1,9 +1,7 @@
-Hello {{ attendee.first_name }},
+<p>Hello {{ attendee.first_name }},</p>
 
-Our records show that you will be receiving a t-shirt at MAGFest 2016. Please take a moment to review <a href="http://magfest.org/images/2016swag/shirtsizeguide.png">this sizing chart</a>, and then check that you have the right shirt size selected on your <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">registration information page</a> in the the "Shirt Size" dropdown. If you'd like to change your size, please do so using the dropdown, and then click the "Update My Info" button. If you're satisfied with the shirt size that is already selected, then no further action is necessary.
+<p>Our records show that you will be receiving a t-shirt at MAGFest 2016. Please take a moment to review <a href="http://magfest.org/images/2016swag/shirtsizeguide.png">this sizing chart</a>, and then check that you have the right shirt size selected on your <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">registration information page</a> in the the "Shirt Size" dropdown. If you'd like to change your size, please do so using the dropdown, and then click the "Update My Info" button. If you're satisfied with the shirt size that is already selected, then no further action is necessary.</p>
 
-Please make sure that we have your desired shirt size no later than <b>January 15th, 2016</b>, so that we can ensure we have enough stock for your size. Your shirt will be available for pickup at the MAGFest merchandise booth.
+<p>Please make sure that we have your desired shirt size no later than <b>January 15th, 2016</b>, so that we can ensure we have enough stock for your size. Your shirt will be available for pickup at the MAGFest merchandise booth.</p>
 
-Ryan Nichols
-MAGFest Merch Department
-merch@magfest.org
+<p>Ryan Nichols<br>MAGFest Merch Department<br>merch@magfest.org</p>

--- a/magprime/templates/emails/confirm_shirt_size.html
+++ b/magprime/templates/emails/confirm_shirt_size.html
@@ -1,0 +1,9 @@
+Hello {{ attendee.first_name }},
+
+Our records show that you will be receiving a t-shirt at MAGFest 2016. Please take a moment to review <a href="http://magfest.org/images/2016swag/shirtsizeguide.png">this sizing chart</a>, and then check that you have the right shirt size selected on your <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">registration information page</a> in the the "Shirt Size" dropdown. If you'd like to change your size, please do so using the dropdown, and then click the "Update My Info" button. If you're satisfied with the shirt size that is already selected, then no further action is necessary.
+
+Please make sure that we have your desired shirt size no later than <b>January 15th, 2016</b>, so that we can ensure we have enough stock for your size. Your shirt will be available for pickup at the MAGFest merchandise booth.
+
+Ryan Nichols
+MAGFest Merch Department
+merch@magfest.org

--- a/magprime/templates/emails/confirm_shirt_size.html
+++ b/magprime/templates/emails/confirm_shirt_size.html
@@ -1,3 +1,7 @@
+<html>
+<head></head>
+<body>
+  
 <p>Hello {{ attendee.first_name }},</p>
 
 <p>Our records show that you will be receiving a t-shirt at MAGFest 2016. Please take a moment to review <a href="http://magfest.org/images/2016swag/shirtsizeguide.png">this sizing chart</a>, and then check that you have the right shirt size selected on your <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">registration information page</a> in the the "Shirt Size" dropdown. If you'd like to change your size, please do so using the dropdown, and then click the "Update My Info" button. If you're satisfied with the shirt size that is already selected, then no further action is necessary.</p>
@@ -5,3 +9,6 @@
 <p>Please make sure that we have your desired shirt size no later than <b>January 15th, 2016</b>, so that we can ensure we have enough stock for your size. Your shirt will be available for pickup at the MAGFest merchandise booth.</p>
 
 <p>Ryan Nichols<br>MAGFest Merch Department<br>merch@magfest.org</p>
+
+</body>
+</html>


### PR DESCRIPTION
Since we introduced fitted t-shirts, the measurements of those shirts has been unclear to the attendees, and we have not had a sizing guide until now.

This e-mail will inform everyone in uber eligible for a shirt that they should refer to the size guide to ensure they have the right t-shirt size selected.