### PR TITLE
potential fix for email code not working

### DIFF
--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -1,11 +1,11 @@
 from magprime import *
 
-AutomatedEmail.extra_models['SeasonPass'] = lambda session: session.season_passes()
+AutomatedEmail.extra_models[SeasonPassTicket] = lambda session: session.season_passes()
 
 
 class SeasonSupporterEmail(AutomatedEmail):
     def __init__(self, event):
-        AutomatedEmail.__init__(self, 'SeasonPass',
+        AutomatedEmail.__init__(self, SeasonPassTicket,
                                 subject='Claim your {} tickets with your MAGFest Season Pass'.format(event.name),
                                 template='season_supporter_event_invite.txt',
                                 filter=lambda a: before(event.deadline),


### PR DESCRIPTION
This fixes emails from crashing out after a series of recent optimizations.

@EliAndrewC I think this fixes it based on what I have seen other parts of the code doing.  But, I don't know the intricacies of the extra_models part of AutomatedEmails so you will want to inspect this really carefully.

This would have caused the following categories of emails to not send (due to their ordering after SeasonPassTicket):
* SeasonPassTicket
* Room
* IndieStudio