### PR TITLE
Add report on invalid attendees

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -1,6 +1,18 @@
 from magprime import *
 
 
+@Session.model_mixin
+class Attendee:
+    @presave_adjustment
+    def invalid_notification(self):
+        if self.staffing and self.badge_status == c.INVALID_STATUS and self.badge_status != self.orig_value_of('badge_status'):
+            try:
+                send_email(c.STAFF_EMAIL, c.STAFF_EMAIL, 'Volunteer invalidated',
+                           render('emails/invalidated_volunteer.txt', {'attendee': self}), model=self)
+            except:
+                log.error('unable to send invalid email')
+
+
 class SeasonPassTicket(MagModel):
     fk_id    = Column(UUID)
     slug     = Column(UnicodeText)

--- a/magprime/site_sections/magprime_reports.py
+++ b/magprime/site_sections/magprime_reports.py
@@ -1,0 +1,15 @@
+from magprime import *
+
+
+@all_renderable(c.PEOPLE)
+class Root:
+    def index(self, session):
+        from hotel import RoomAssignment
+        return {
+            'invalids': session.query(Attendee)
+                               .options(subqueryload(Attendee.room_assignments).joinedload(RoomAssignment.room),
+                                        subqueryload(Attendee.shifts).joinedload(Shift.job))
+                               .filter_by(staffing=True,
+                                          badge_status=c.INVALID_STATUS)
+                               .order_by(Attendee.full_name).all()
+        }

--- a/magprime/templates/emails/invalidated_volunteer.txt
+++ b/magprime/templates/emails/invalidated_volunteer.txt
@@ -1,0 +1,8 @@
+{{ attendee.full_name }} has just been marked as invalid.
+
+Here is some info about this volunteer:
+
+- Admin form: {{ c.URL_BASE }}/registration/form?id={{ attendee.id }}
+- Departments: {{ attendee.assigned_depts_labels|join:" / " }}
+- Weighted Hours: {{ attendee.weighted_hours }}
+- Hotel room assignments: {{ attendee.room_assignments|yesno }}

--- a/magprime/templates/magprime_reports/index.html
+++ b/magprime/templates/magprime_reports/index.html
@@ -1,0 +1,41 @@
+{% extends "base-admin.html" %}
+{% block title %}Invalid Volunteers{% endblock %}
+{% block content %}
+
+<h2>Invalid Volunteers</h2>
+
+There are {{ invalids|length }} volunteers in the system whose badges are marked as "invalid",
+presumably because they clicked the "I'm not coming" button.
+
+<table style="width:100%">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Hours</th>
+            <th>Assigned Hotel Room</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for attendee in invalids %}
+        <tr>
+            <td>{{ attendee|form_link }}</td>
+            <td>
+                {% if attendee.weighted_hours %}
+                    <a href="../registration/shifts?id={{ attendee.id }}">{{ attendee.weighted_hours }}</a>
+                {% else %}
+                    0
+                {% endif %}
+            </td>
+            <td>
+                {% for room in attendee.rooms %}
+                    <a href="../hotel_assignments/index#/add-to-room/{{ room.id }}">{{ room.nights_labels|join:" / " }}</a>
+                {% empty %}
+                    no
+                {% endfor %}
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+{% endblock %}


### PR DESCRIPTION
This implements https://github.com/magfest/ubersystem/issues/1668

I didn't add this to the core repo, because it's a temporary workaround for an issue we'll fix more robustly next year, specifically the fact that someone clicking "I'm not coming" doesn't clear their shifts / hotel / food preferences / etc.