### PR TITLE
turn off badge locking for magprime

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -30,3 +30,24 @@ class PrevSeasonSupporter(MagModel):
     email_model_name = 'attendee'  # used by AutomatedEmail code
 
     _repr_attr_names = ['first_name', 'last_name', 'email']
+
+
+class FakeBadgeLock:
+    """
+    When c.SHIFT_CUSTOM_BADGES is turned on, we protect badge shifting with the
+    c.BADGE_LOCK property.  Unfortunately, we've seen some bugs with this in the
+    past where the lock might not get released after a database exception.  Since
+    badge shifting is turned off for us now, I'm going to disable this lock via
+    this dump monkeypatch, with the intention of straightening the whole thing
+    out after MAGFest.
+    """
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback): pass
+
+    def acquire(self): pass
+
+    def release(self): pass
+
+c.BADGE_LOCK = FakeBadgeLock()


### PR DESCRIPTION
See the comment for an explanation.  In case it's not clear, this isn't eliminating any non-badge-shifting safety checks, because we weren't even using the badge lock to guard most of those.

In the meantime this is a workaround for https://github.com/magfest/ubersystem/issues/1085 which I never had time to look at.