### PR TITLE
disabled price bump warnings after prereg has officially closed

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -29,6 +29,16 @@
                 $(".badge-type-selector").parents('.form-group').hide();
             }
         {% endif %}
+
+        {% if c.AFTER_PREREG_TAKEDOWN %}
+            // MAGFest leaves prereg running after the supposed "deadline", so we want to turn off the warnings.
+            var origTogglePrices = window.togglePrices;
+            window.togglePrices = function () {
+                origTogglePrices();
+                $('.prereg-type-closing').empty();
+            };
+            togglePrices();
+        {% endif %}
     });
 </script>
 


### PR DESCRIPTION
After we move over to the onsite servers, we want to turn prereg back on at the at-the-door price.  When this happens we don't want to show scary warnings about "prereg goes offline at ____", so this removes those.