### PR TITLE
Stop setting ribbon to None when adjusting badge type based on age

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -28,7 +28,7 @@ class Attendee:
     def child_to_attendee(self):
         if self.badge_type == c.CHILD_BADGE and self.age_group in [c.UNDER_21, c.OVER_21]:
             self.badge_type = c.ATTENDEE_BADGE
-            self.ribbon = None
+            self.ribbon = c.NO_RIBBON
 
 
 class SeasonPassTicket(MagModel):


### PR DESCRIPTION
Attendees' ribbons can't be Null, so the database would throw an error when we tried to set it to None. This fixes that.