### PR TITLE
Move kick-in selection to just below reg-types

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -34,7 +34,6 @@
             // These are explanatory fields for attendees, so admins don't need to see them
             // #tax_exempt tells people that MAGFest is a 501(c)(3) nonprofit
             if ($.field('amount_extra')) {
-                $.field('amount_extra').parents('.form-group').insertAfter($("#reg-types"));
                 $.field('amount_extra').parents('.form-group').find('.help-block').hide();
                 $.field('amount_extra').parents('.form-group').append($('#tax_exempt'));
             }

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -3,7 +3,8 @@
         if (window.REG_TYPES) {
             REG_TYPES.options.push({
                 title: 'Child: $' + ({{ c.BADGE_PRICE }} / 2),
-                description: '<p class="list-group-item-text">Attendees under 13 must be accompanied by an adult with a valid Attendee badge.</p>',
+                description: '<p class="list-group-item-text">Attendees under 13 must be accompanied by an adult with a valid Attendee badge.</p>' +
+            '<span class="prereg-price-notice">Price is always half that of the Single Attendee badge price.</span>',
                 onClick: function () {
                     $('.group_fields').addClass('hide');
                     if ($.field('first_name')) {
@@ -33,6 +34,8 @@
             // These are explanatory fields for attendees, so admins don't need to see them
             // #tax_exempt tells people that MAGFest is a 501(c)(3) nonprofit
             if ($.field('amount_extra')) {
+                $.field('amount_extra').parents('.form-group').insertAfter($("#reg-types"));
+                $.field('amount_extra').parents('.form-group').find('.help-block').hide();
                 $.field('amount_extra').parents('.form-group').append($('#tax_exempt'));
             }
             


### PR DESCRIPTION
Also hides the help-block that contains the text in https://github.com/magfest/magprime/issues/115.

Looks like:
![screenshot from 2016-08-10 18-47-50](https://cloud.githubusercontent.com/assets/7198215/17573849/1bf39e80-5f2b-11e6-8b56-8f1a4f2055a9.png)

ALSO fixes #103.