### PR TITLE
Stops listing all the tiers as items in the prereg confirmation email

### DIFF
--- a/magprime/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/magprime/templates/emails/reg_workflow/attendee_confirmation.html
@@ -24,12 +24,7 @@ Badges are not mailed out before the event, so your badge will be available for 
 
 {% if attendee.amount_extra %}
     <br/> <br/>
-    Your additional contribution of ${{ attendee.amount_extra }} provides you with these bonus items, which may be picked up at our merch booth:
-    <ul>
-    {% for swag in attendee.donation_swag %}
-        <li>{{ swag }}</li>
-    {% endfor %}
-    </ul>
+    Your additional contribution of ${{ attendee.amount_extra }} provides you with the "{{ attendee.amount_extra_label }}" level bonus items, which can be picked up from our merch booth at the fest.
 {% endif %}
 {% if attendee.extra_donation %}
     <br/>


### PR DESCRIPTION
Fixes #116.

I was not able to test this on my dev system because I can't get the Stripe test mode to work (likely due to Glorious Hotel Internet), so we will need to test this on staging before deploying to prod.