### PR TITLE
Round Child badge prices to dollars only

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -15,7 +15,7 @@ class Attendee:
     @cost_property
     def child_discount(self):
         if 'val' in self.age_group_conf and self.age_group_conf['val'] == c.UNDER_13:
-            return (c.BADGE_PRICE / 2) * -1
+            return math.ceil(c.BADGE_PRICE / 2) * -1
         return 0
 
     @presave_adjustment

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -2,7 +2,7 @@
     {% if attendee.is_new and not group_id %}
         if (window.REG_TYPES) {
             REG_TYPES.options.push({
-                title: 'Child: $' + ({{ c.BADGE_PRICE }} / 2),
+                title: 'Child: $' + Math.floor({{ c.BADGE_PRICE }} / 2),
                 description: '<p class="list-group-item-text">Attendees under 13 must be accompanied by an adult with a valid Attendee badge.</p>' +
             '<span class="prereg-price-notice">Price is always half that of the Single Attendee badge price.</span>',
                 onClick: function () {


### PR DESCRIPTION
Fixes https://github.com/magfest/magprime/issues/136. It turns out that the system and the database are built around charging only dollar amounts, and refactoring that is out of scope for launching MAGPrime, so we now round up when calculating the discount.