### PR TITLE
Don't give OVER_13 ribbons to attendees under 13

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -19,10 +19,11 @@ class Attendee:
         return 0
 
     @presave_adjustment
-    def child_badge_under_18(self):
+    def child_badge(self):
         if self.age_group not in [c.UNDER_21, c.OVER_21, c.AGE_UNKNOWN]:
             self.badge_type = c.CHILD_BADGE
-            self.ribbon = c.OVER_13
+            if self.age_group == c.UNDER_18:
+                self.ribbon = c.OVER_13
 
     @presave_adjustment
     def child_to_attendee(self):


### PR DESCRIPTION
We had a presave adjustment that would give an "Over 13" ribbon to attendees assuming they're in the UNDER_18 age group, but this is not always the case. This fixes it.