### PR TITLE
fix-#1976

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -71,7 +71,7 @@
 
         // MAGFest uses tiered badge pricing based on caps, so we want to link to our FAQ explaining this
         if ($('.prereg-price-notice').size()) {
-            $('#reg-types').append('<div class="help-block col-sm-6 col-sm-offset-2">Prices may increase before the set date. {% popup_link "http://magfest.org/faq#-KOpcFnNhdsUIqvvf6VB" "Why is this?" %}</div>')
+            $('#reg-types').append("<div class=\"help-block col-sm-6 col-sm-offset-2\">Prices may increase before the set date. {% escaped_popup_link "http://magfest.org/faq#-KOpcFnNhdsUIqvvf6VB" "Why is this?" %}</div>")
         }
     });
 </script>


### PR DESCRIPTION
The problem is that popup_link uses a mix of double and single quotes making it very tough to use inside in-line javascript.

MERGE WITH OTHER FROM UBERSYSTEM REPO