### PR TITLE
Stop increasing prices for already-paid attendees

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -10,7 +10,7 @@ class Group:
                 self.cost = self.amount_paid - self.amount_extra
                 self.auto_recalc = False
             if self.is_new:
-                self.cost = self.default_cost
+                self.cost = self.cost or self.default_cost
 
 
 @Session.model_mixin
@@ -32,7 +32,7 @@ class Attendee:
 
     @presave_adjustment
     def bucket_pricing_workaround(self):
-        if not self.overridden_price:
+        if not self.overridden_price and self.paid in [c.HAS_PAID, c.NOT_PAID]:
             self.overridden_price = self.default_cost if self.is_new else self.amount_paid - self.amount_extra
 
     @presave_adjustment


### PR DESCRIPTION
So it turns out that the system is built around fetching a new price every time we touch an attendee. This becomes a problem with the new bucket-based pricing, because we have no way to tell the function, 'this is how many badges were sold at the time the attendee registered'. This attempts to work around that on an emergency basis. Requires https://github.com/magfest/ubersystem/pull/1982. Fixes https://github.com/magfest/ubersystem/issues/1981.