### PR TITLE
Stop telling every attendee that their badge is discounted

### DIFF
--- a/magprime/templates/preregistration/attendee_donation_form.html
+++ b/magprime/templates/preregistration/attendee_donation_form.html
@@ -1,0 +1,37 @@
+{% extends "./preregistration/preregbase.html" %}
+{% block title %}Additional Donation{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+<div class="masthead">
+</div>
+<div class="panel panel-default">
+{% if attendee.paid == c.NOT_PAID or attendee.overridden_price %}
+    <h2> Badge Payment for {{ attendee.full_name }} </h2>
+
+    You've registered for {{ c.EVENT_NAME }} at the price of ${{ attendee.overridden_price|default:attendee.badge_cost|floatformat:2 }}{% if attendee.amount_extra %} and you've also kicked in ${{ attendee.amount_extra|floatformat:2 }}{% endif %}; your total outstanding balance is ${{ attendee.amount_unpaid|floatformat:2 }}.
+
+    <table style="width:auto ; margin-left:auto ; margin-right: auto"><tr>
+        <td>{% stripe_form process_attendee_donation charge %}</td>
+        {% if attendee.amount_extra %}
+            <td style="width:100px ; text-align:center">or</td>
+            <td><a href="undo_attendee_donation?id={{ attendee.id }}">{% stripe_button "Undo Extra Money" %}</a></td>
+        {% endif %}
+    </tr></table>
+{% else %}
+    <h2> Extra Payment for {{ attendee.full_name }} </h2>
+
+    Thanks for offering to kick in money to help make {{ c.EVENT_NAME }} better.  As thanks, your total donation (of which ${{ attendee.amount_unpaid|floatformat:2 }} is outstanding) entitles you to the following:
+    <ul>
+        {% for swag in attendee.donation_swag|add:attendee.addons %}
+            <li>{{ swag }}</li>
+        {% endfor %}
+    </ul>
+
+    <table style="width:auto ; margin-left:auto ; margin-right: auto"><tr>
+        <td>{% stripe_form process_attendee_donation charge %}</td>
+        <td style="width:100px ; text-align:center">or</td>
+        <td><a href="undo_attendee_donation?id={{ attendee.id }}">{% stripe_button "Nevermind" %}</a></td>
+    </tr></table>
+{% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Because we use overridden_price to get around the bucket pricing bug, the extra payment form was telling any attendee that their badge price was discounted. This removes the check entirely so attendees don't get confused.