### PR TITLE
Fix minor display errors on the kiosk page

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -28,6 +28,8 @@
         // This places our "Extra Donation" form after our kick-in selection area.
         if ($.field('amount_extra')) {
             $('#extra_donation').insertAfter($.field('amount_extra').parents('.form-group'));
+        } else {
+            $('#extra_donation').insertBefore($.field('staffing').parents('.form-group'));
         }
 
         if ($.field('payment_method')) {
@@ -80,7 +82,7 @@
     });
 </script>
 
-{% if c.PAGE_PATH != '/registration/register' %}
+{% if c.PAGE_PATH == '/registration/register' %}
 <div id="price_explanation">
     <div class="form-group">
     <p class="help-block col-sm-6 col-sm-offset-2">


### PR DESCRIPTION
This gives a fallback position for extra_donation if amount_extra does not exist, and fixes a bug so that the child explanation shows ONLY on the kiosk page, not only NOT on the kiosk page.