### PR TITLE
Stop charging staff badges in groups

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -20,7 +20,7 @@ class Attendee:
 
     @presave_adjustment
     def bucket_pricing_workaround(self):
-        if not self.overridden_price:
+        if self.overridden_price is None:
             self.overridden_price = self.badge_cost
         elif self.extra_donation and self.overridden_price == self.default_cost:
             self.overridden_price -= self.extra_donation


### PR DESCRIPTION
A slight oversight in the way we set up badge_cost for groups meant that if a staff was paid_by_group, they'd be treated as a regular attendee. Our overridden_price setting also was not respecting an overridden price of $0. This fixes both those problems.