### PR TITLE
fixed who should get the precon faq

### DIFF
--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -16,7 +16,9 @@ for _event in SeasonEvent.instances.values():
 
 
 AutomatedEmail(Attendee, 'MAGFest schedule, maps, and other FAQs', 'precon_faqs.html',
-               filter=lambda a: True,
+               filter=lambda a: a.badge_status not in [c.INVALID_STATUS, c.DEFERRED_STATUS]
+                            and a.paid != c.NOT_PAID
+                            and (a.paid != c.PAID_BY_GROUP or a.group and not a.group.amount_unpaid),
                when=days_before(7, c.EPOCH))
 
 AutomatedEmail(Attendee, 'MAGFest food for guests', 'guest_food_restrictions.txt',


### PR DESCRIPTION
The past few years we've accidentally sent out the precon FAQ to people with unpaid badges and people with invalid badges, etc.  This fixes that so that only people with valid badges get the email.