### PR TITLE
Remove base-admin.html

### DIFF
--- a/magprime/templates/magprime_reports/index.html
+++ b/magprime/templates/magprime_reports/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Invalid Volunteers{% endblock %}
 {% block content %}
 

--- a/magprime/templates/magprime_reports/volunteer_food.html
+++ b/magprime/templates/magprime_reports/volunteer_food.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Volunteers Needing Food{% endblock %}
 {% block content %}
 

--- a/magprime/templates/season_supporters/index.html
+++ b/magprime/templates/season_supporters/index.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Season Pass Tickets{% endblock %}
 {% block content %}
 

--- a/magprime/templates/season_supporters/prev_supporters.html
+++ b/magprime/templates/season_supporters/prev_supporters.html
@@ -1,4 +1,4 @@
-{% extends "base-admin.html" %}
+{% extends "base.html" %}{% set admin_area=True %}
 {% block title %}Previous Supporters{% endblock %}
 {% block content %}
 


### PR DESCRIPTION
Now that we have Jinja2 templating, we can use the variable admin_area to control what gets included in child templates, rather than inheriting from a different template. We're implementing that now.