### PR TITLE
Add more robust check for Extra Donation field

### DIFF
--- a/magprime/__init__.py
+++ b/magprime/__init__.py
@@ -55,11 +55,6 @@ class Attendee:
         if not self.extra_donation:
             self.extra_donation = 0
 
-    @validation.Attendee
-    def only_positive_donation(self):
-        if self.extra_donation and self.extra_donation < 0:
-            return "You cannot donate negative money."
-
     @property
     def addons(self):
         return ['Extra donation of ${}'.format(self.extra_donation)] if self.extra_donation else []

--- a/magprime/model_checks.py
+++ b/magprime/model_checks.py
@@ -1,6 +1,16 @@
 from magprime import *
 
 
+@validation.Attendee
+def extra_donation_valid(attendee):
+    try:
+        extra_donation = int(float(attendee.extra_donation if attendee.extra_donation else 0))
+        if extra_donation < 0:
+            return 'Extra Donation must be a number that is 0 or higher.'
+    except:
+        return "What you entered for Extra Donation ({}) isn't even a number".format(attendee.extra_donation)
+
+
 @prereg_validation.Attendee
 def child_badge_over_13(attendee):
     if attendee.is_new and attendee.badge_type == c.CHILD_BADGE and attendee.age_group_conf['val'] not in [c.UNDER_6, c.UNDER_13]:

--- a/magprime/tests/test_model_checks.py
+++ b/magprime/tests/test_model_checks.py
@@ -1,0 +1,16 @@
+import pytest
+
+from uber.common import *
+from magprime.model_checks import *
+
+
+class TestAttendeeValidations:
+
+    def test_extra_donation_nan(self):
+        assert "What you entered for Extra Donation (blah) isn't even a number" == extra_donation_valid(Attendee(extra_donation="blah"))
+
+    def test_extra_donation_below_zero(self):
+        assert "Extra Donation must be a number that is 0 or higher." == extra_donation_valid(Attendee(extra_donation=-10))
+
+    def test_extra_donation_valid(self):
+        assert None == extra_donation_valid(Attendee(extra_donation=10))


### PR DESCRIPTION
We were checking to see if extra_donation was more than 0, but we weren't accounting for if an attendee entered something that wasn't even a number. We now account for both, and in model_checks.py instead of `__init__.py`. Fixes https://github.com/magfest/magprime/issues/108.