### PR TITLE
Add offset = 2 to price notice explanation

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -78,7 +78,7 @@
 
         // MAGFest uses tiered badge pricing based on caps, so we want to link to our FAQ explaining this
         if ($('.prereg-price-notice').size()) {
-            $('#reg-types').append("<div class='help-block col-sm-6 col-sm-offset-'>Prices may increase before the set date. {{ macros.popup_link("http://magfest.org/faq#-KOpcFnNhdsUIqvvf6VB", "Why is this?") }}</div>");
+            $('#reg-types').append('<div class="help-block col-sm-6 col-sm-offset-2">Prices may increase before the set date. {{ macros.popup_link("http://magfest.org/faq#-KOpcFnNhdsUIqvvf6VB", "Why is this?") }}</div>');
         }
     });
 </script>

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -78,7 +78,7 @@
 
         // MAGFest uses tiered badge pricing based on caps, so we want to link to our FAQ explaining this
         if ($('.prereg-price-notice').size()) {
-            $('#reg-types').append('<div class="help-block col-sm-6 col-sm-offset-2">Prices may increase before the set date. {{ macros.popup_link("http://magfest.org/faq#-KOpcFnNhdsUIqvvf6VB", "Why is this?") }}</div>');
+            $('#reg-types').append("<div class='help-block col-sm-6 col-sm-offset-2'>Prices may increase before the set date. {{ macros.popup_link("http://magfest.org/faq#-KOpcFnNhdsUIqvvf6VB", "Why is this?")|e }}</div>");
         }
     });
 </script>


### PR DESCRIPTION
Fixes https://github.com/magfest/magprime/issues/200. When we converted our Django templates to Jinja2 templates, we took out a function from the popup macro that turned `'`s into `&quot;`s. We weren't sure if we needed it, but it turns out we do -- it's the only way to properly escape quotes when including the macro inside a quoted element, as in https://github.com/magfest/magprime/issues/200. We also needed to switch the `"`s to `'`s in our magprime template to complete the fix.