### PR TITLE
Fixes magfest/ubersystem#2595: Removes vestigial swag links

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -128,22 +128,4 @@
             <em>Slim fit sizes only available during online pre-order. {{ macros.popup_link("http://magfest.org/images/2016swag/shirtsizeguide.png", "Size guide.") }}</em>
         </div>
     </div>
-
-    <span id="guitar_keychain">
-        ({{ macros.popup_link("http://magfest.org/sites/default/files/keychainsample.png", "Art Preview") }})
-    </span>
-
-    {% if c.BEFORE_SUPPORTER_DEADLINE %}
-        <span id="canvas_print">
-            ({{ macros.popup_link("http://magfest.org/sites/default/files/canvassample.png", "Art Preview") }})
-        </span>
-
-        <span id="supporter_popup">
-            ({{ macros.popup_link("../static_views/supporters.html", "What's included?") }})
-        </span>
-
-        <span id="season_popup">
-            ({{ macros.popup_link("../static_views/seasonPasses.html", "What's included?") }})
-        </span>
-    {% endif %}
 {% endif %}


### PR DESCRIPTION
Fixes magfest/ubersystem#2595: Removes vestigial swag links.

We can put them back if we end up needing them.