### PR TITLE
Removes a <br> tag in the dealer website help block 

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -83,7 +83,7 @@
 
         if ($.field('website')) {
             $.field('website').parents('.form-group').find('.help-block').html('Dealers who don\'t provide a ' +
-                'website that includes images <br/>of their wares will be automatically waitlisted.')
+                'website that includes images of their wares will be automatically waitlisted.')
         }
     });
 </script>


### PR DESCRIPTION
Working on the dealer application page when I noticed the `<br>` tag in the middle of the help block was causing weird layout flow on small screen sizes.

See attached screenshots...

<img width="758" alt="screen shot 2017-07-20 at 9 53 53 pm" src="https://user-images.githubusercontent.com/2592431/28446163-f12fa1c8-6d96-11e7-8070-feaa429cd5bd.png">

<img width="414" alt="screen shot 2017-07-20 at 9 53 16 pm" src="https://user-images.githubusercontent.com/2592431/28446167-f70ea5a8-6d96-11e7-89aa-923fccbfcc4e.png">
