### PR TITLE
Add blurb about free staff rooms to hotel booking info email

### DIFF
--- a/magprime/templates/emails/reg_workflow/hotel_booking_info.html
+++ b/magprime/templates/emails/reg_workflow/hotel_booking_info.html
@@ -1,0 +1,30 @@
+<html>
+<head></head>
+<body>
+
+<p>{{ attendee.first_name }},</p>
+
+<p>
+You've expressed interest in booking a hotel room for {{ c.EVENT_NAME }} this
+coming {{ event_dates() }}. Follow the link below to view all available
+{{ c.EVENT_NAME }} hotels with discounted event room rates:
+</p>
+
+<p><a href="{{ c.PREREG_HOTEL_INFO_LINK }}">{{ c.PREREG_HOTEL_INFO_LINK }}</a></p>
+
+{% if attendee.hotel_eligible %}<p>
+    <strong>This is not the link to sign up for staff hotel rooms.</strong>
+    You are currently eligible for free hotel space, so please only buy a room
+    if you intend to opt out of a staff room later this year.
+</p>{% endif %}
+
+<p>This email is being sent to registered {{ c.EVENT_NAME }} attendees before
+being released to the general public, but does not guarantee room availability.
+Out of respect for fellow attendees, please do not share this link.</p>
+
+<p>Please let us know if you have any questions.</p>
+
+<p>{{ c.REGDESK_EMAIL_SIGNATURE }}</p>
+
+</body>
+</html>


### PR DESCRIPTION
Fixes https://github.com/magfest/ubersystem/issues/2692. I had to do this in the magprime repo because it depends on the hotel plugin -- attendees in the core plugin don't have a `hotel_eligible` property.