### PR TITLE
Add 'confirmed' column for placeholder badge confirmations

### DIFF
--- a/magprime/templates/emails/reg_workflow/attendee_confirmation.html
+++ b/magprime/templates/emails/reg_workflow/attendee_confirmation.html
@@ -3,8 +3,16 @@
 <body>
 
 You ({{ attendee.full_name }}) have preregistered for {{ c.EVENT_NAME }} this coming {{ event_dates() }}
+{% if attendee.promo_code_id %}
+    using promotional code {{ attendee.promo_code.code }}
+{% endif %}
+
 {% if attendee.group %}
     by claiming one of the badges in the {{ attendee.group.name }} group.
+{% elif attendee.paid == c.NEED_NOT_PAY and attendee.promo_code_id %}
+    to claim a free badge.
+{% elif attendee.paid == c.NEED_NOT_PAY %}
+    by claiming your free badge.
 {% else %}
     and your payment of ${{ attendee.amount_paid }} has been received.
 {% endif %}
@@ -13,6 +21,11 @@ Your registration confirmation number is {{ attendee.id }}, and you can update y
     even more
 {% endif %}
 extra money <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">here</a>.
+
+{% if attendee.is_group_leader %}
+    If you don't remember claiming a badge, it may have been created for you by {{ c.EVENT_NAME }} staff. Please
+    check your information to make sure it is correct.
+{% endif %}
 
 <br/> <br/>
 


### PR DESCRIPTION
Prevents emails from going out to placeholder badges long after they were confirmed by keeping track of when they were confirmed. Also updates the email text to reflect this -- we no longer show the disclaimer about "if you don't remember claiming a badge" to non-group-leaders. Reopens https://github.com/magfest/ubersystem/issues/1709.