### PR TITLE
OFFICE-1304: added automated email

### DIFF
--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -91,6 +91,11 @@ StopsEmail('MAGFest Dept Checklist Introduction', 'dept_checklist_intro.txt',
            lambda a: a.is_checklist_admin and a.admin_account,
            ident='magprime_dept_checklist_intro')
 
+StopsEmail('Last Chance to enter your MAGFest staff shirt preferences', 'second_shirt.html',
+           lambda a: not a.shirt_info_marked,
+           when=days_before(21, c.SHIRT_DEADLINE),
+           ident='magprime_second_shirt')
+
 AutomatedEmail(Attendee, 'Last Chance for MAGFest ' + c.YEAR + ' bonus swag!', 'attendee_swag_promo.html',
                lambda a: a.can_spam and
                          (a.paid == c.HAS_PAID or a.paid == c.NEED_NOT_PAY or (a.group and a.group.amount_paid)) and

--- a/magprime/templates/emails/second_shirt.html
+++ b/magprime/templates/emails/second_shirt.html
@@ -1,0 +1,18 @@
+<html>
+<head></head>
+<body>
+
+<p>Hello {{ attendee.first_name }},</p>
+
+<p>
+    You are receiving this e-mail because you're a staffer eligible for complimentary shirts.
+    We've <a href="{{ c.URL_BASE }}/signups/shirt_size">added a step to the volunteer checklist</a>
+    for you to read our staff shirt policy, and choose whether you'd like two staff shirts, or
+    substitute one of them for the standard event themed swag shirt. We are printing shirts very soon,
+    so please complete this step no later than <b>{{ c.SHIRT_DEADLINE|datetime_local }}</b>.
+</p>
+
+<p>{{ c.STOPS_EMAIL_SIGNATURE|linebreaksbr }}</p>
+
+</body>
+</html>


### PR DESCRIPTION
NOTE: Nick is encouraging paid MAGFolks to take Thanksgiving weekend off. I'm on vacation having fun getting caught up on some programming work, but others are encouraged to take it easy and pick this up on Monday. This needs to get deployed by COB Monday, but it's okay to wait until then.

This adds the automated email for the extra shirt info on the volunteer checklist in this PR:
 https://github.com/magfest/ubersystem/pull/2973/files

I've tested this out locally on Vagrant using a database dump of our production database to see it work on a real data set.