### PR TITLE
disable season supporter emails

### DIFF
--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -1,19 +1,25 @@
 from magprime import *
 
-AutomatedEmail.queries[SeasonPassTicket] = lambda session: session.season_passes()
+# leave this off for now, this code is now old and needs updating
+_send_season_supporter_emails = False
 
 
-class SeasonSupporterEmail(AutomatedEmail):
-    def __init__(self, event):
-        AutomatedEmail.__init__(self, SeasonPassTicket,
-                                subject='Claim your {} tickets with your MAGFest Season Pass'.format(event.name),
-                                ident='magprime_season_supporter_{}_invite'.format(event.slug),
-                                template='season_supporter_event_invite.txt',
-                                when=before(event.deadline),
-                                extra_data={'event': event})
+if _send_season_supporter_emails:
+    # This line currently does, but should not, return Attendee objects.
+    # It can cause issues. see _assert_same_model_type()
+    # !!THIS LINE IS BROKEN!! # AutomatedEmail.queries[SeasonPassTicket] = lambda session: session.season_passes()
 
-for _event in SeasonEvent.instances.values():
-    SeasonSupporterEmail(_event)
+    class SeasonSupporterEmail(AutomatedEmail):
+        def __init__(self, event):
+            AutomatedEmail.__init__(self, SeasonPassTicket,
+                                    subject='Claim your {} tickets with your MAGFest Season Pass'.format(event.name),
+                                    ident='magprime_season_supporter_{}_invite'.format(event.slug),
+                                    template='season_supporter_event_invite.txt',
+                                    when=before(event.deadline),
+                                    extra_data={'event': event})
+
+    for _event in SeasonEvent.instances.values():
+        SeasonSupporterEmail(_event)
 
 
 AutomatedEmail(Attendee, 'MAGFest schedule, maps, and other FAQs', 'precon_faqs.html',


### PR DESCRIPTION
- these are old, we don't use Season Supporter tickets anymore, and they're now broken
- they are causing issues with some emails being sent twice, so cut em

this is a lame, but effective, solution to https://github.com/magfest/ubersystem/issues/2984

to bring this back to the dead likely requires a bit of a rethink of how the modern email system queries work for Season Supporters (for instance, do we need to do what it was trying to do anymore?).  in reality, we probably shouldn't attempt multi-event stuff until Reggie is going, which will make doing this kind of thing really simple.