### PR TITLE
Remove dealer 'website' field help text override

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -83,14 +83,6 @@
         if ($('.prereg-price-notice').size()) {
             $('#reg-types').append("<div class='help-block col-sm-9 col-sm-offset-3'>"+ bucket_notice + "</div>");
         }
-
-        if ($.field('website')) {
-            $.field('website').parents('.form-group').find('.help-block').html(
-                'A website is required to view what you plan to sell in the Marketplace--it can ' +
-                'be a link to your business page, online shop, facebook, tumblr (with appropriate ' +
-                'tag for your art), etc. If no link is provided, then you will be automatically ' +
-                'waitlisted because we cannot fully evaluate your wares or application.');
-        }
     });
 </script>
 


### PR DESCRIPTION
The new text provided in MAGDEV-252 is perfectly suitable for other events, and also much shorter, so let's get rid of this huge block.