### PR TITLE
Emergency fix for new food policies

### DIFF
--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -55,7 +55,7 @@ AutomatedEmailFixture(
 
 AutomatedEmailFixture(
     Attendee, 'Department Heads', 'food/department_heads.txt',
-    lambda a: a.is_poc and a.admin_account,
+    lambda a: a.is_dept_head,
     ident='magprime_department_water_and_food_info',
    # when=days_before(7, c.UBER_TAKEDOWN),
     sender='MAGFest Staff Suite <chefs@magfest.org>')


### PR DESCRIPTION
This email incorrectly used ``a.is_poc`` which isn't the correct property.

If we wanted to send an email to ONLY department heads who were ALSO the poc for their department, then instead of ``a.is_poc`` we'd do

```python
any(mem.is_poc for mem in a.dept_memberships)
```

However, in this case that's not really what we want anyway - this is an email which is relevant to all department heads.  Therefore I'm just using the ``a.is_dept_head`` property.

The ``is_poc`` property refers only to who should fill out the dept head checklist.  Regardless the list of people who are dept heads and people are are listed as points of contact are almost identical - 102 out of the 108 department heads are listed as points of contact for their departments, so it's probably not worth worrying about either way.