### PR TITLE
Only force sweatpants size selection before the shirt deadline

### DIFF
--- a/magprime/model_checks.py
+++ b/magprime/model_checks.py
@@ -20,7 +20,8 @@ def attendee_badge_under_13(attendee):
 
 @prereg_validation.Attendee
 def sweatpants_size_if_supporter(attendee):
-    if attendee.amount_extra >= c.SUPPORTER_LEVEL and attendee.sweatpants == c.NO_SWEATPANTS:
+    if attendee.amount_extra >= c.SUPPORTER_LEVEL and attendee.sweatpants == c.NO_SWEATPANTS \
+            and c.BEFORE_SHIRT_DEADLINE:
         return "Please select a sweatpants size."
 
 


### PR DESCRIPTION
This should fix https://jira.magfest.net/browse/MAGDEV-405 -- this wouldn't normally be an issue, but since the sweatpants size selection was added well after pre-reg opened we have a bunch of attendees who never selected their size. There isn't a separate sweatpants deadline, so much like the email for sweatpants sizes we just use the shirt deadline.