### PR TITLE
Move MAG-specific text to Super MAG plugin

### DIFF
--- a/magprime/templates/emails/dealers/badge_converted.html
+++ b/magprime/templates/emails/dealers/badge_converted.html
@@ -1,0 +1,19 @@
+<html>
+<head></head>
+<body>
+
+{{ attendee.first_name }},
+
+<br/><br/>
+I am sorry to inform you that all Marketplace spaces have been filled, and unfortunately your group {{ group.name }}
+did not make it into {{ c.EVENT_NAME }} Marketplace this year, which is why your application is now being declined.
+Please try again next year! Dealer Registration opens up at about the same time each year, usually about a week before
+general attendee pre-registration begins. Please follow the MAGFest social media pages to find out when Dealer
+Registration will open next year as we make announcements there before it opens.
+{% if c.PRICE_BUMPS and attendee.badge_cost < c.BADGE_PRICE %}As a courtesy, the badges in your group have been
+converted to attendee badges at the lowest price you could have attained when you applied.{% else %}
+The badges in your group have been converted to attendee badges.{% endif %}
+ You can confirm or decline <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}">your attendee registration here</a>.
+ Again, I am very sorry that you did not make it into the Marketplace this year.
+<br/><br/>
+{{ c.MARKETPLACE_EMAIL_SIGNATURE }}


### PR DESCRIPTION
This was erroneously put in the main plugin despite it mentioning MAGFest by name. We don't seem to have a "all MAG events" plugin anymore, so the second best place is here.