### PR TITLE
Make dealer payment emails automated for Super

### DIFF
--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -1,10 +1,15 @@
-from uber.models import Attendee
+from uber.models import Attendee, AutomatedEmail
 from uber.automated_emails import StopsEmailFixture, AutomatedEmailFixture
 from uber.config import c
 from uber.utils import before, days_after, days_before
 
 from magprime.models import SeasonPassTicket
 from magprime.utils import SeasonEvent
+
+# Super MAGFest's Marketplace is accustomed to not needing to approve these emails
+AutomatedEmail._fixtures['dealer_reg_payment_reminder'].needs_approval = False
+AutomatedEmail._fixtures['dealer_reg_payment_reminder_due_soon'].needs_approval = False
+AutomatedEmail._fixtures['dealer_reg_payment_reminder_last_chance'].needs_approval = False
 
 
 # leave this off for now, this code is now old and needs updating


### PR DESCRIPTION
https://github.com/magfest/ubersystem/pull/3461 is going to change these emails to need approval, but Super MAGFest has had them automated for so long that it'd cause confusion if they suddenly needed approval. This is the workaround.