### PR TITLE
Track deleted dealers

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -105,7 +105,9 @@ class Attendee:
 class Group:
     @presave_adjustment
     def delete_declined(self):
-        if self.status == c.DECLINED:
+        from uber.models import Tracking
+        if self.status == c.DECLINED and not self.is_new:
+            Tracking.track(c.DELETED, self)
             self.session.query(Group).filter_by(id=self.id).delete()
             self.session.expunge(self)
 


### PR DESCRIPTION
Dealers being deleted for being declined weren't showing up in the FODC as deleted, which would be very confusing. This also adds a `is_new` check so that, if we want, we can undelete a decline dealer without it being deleted before it's re-created.