### PR TITLE
Update Dealer confirmation text

### DIFF
--- a/magprime/templates/emails/dealers/application.html
+++ b/magprime/templates/emails/dealers/application.html
@@ -2,12 +2,12 @@
 <head></head>
 <body>
 
-Your group ({{ group.name }}) has successfully submitted a Dealer application for {{ c.EVENT_NAME }}
+Your group ({{ group.name }}) has successfully submitted a Marketplace application for {{ c.EVENT_NAME }}
 this coming {{ event_dates() }}. Below is a copy of your application. You may
 <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">update it here</a> or
 <a href="{{ c.URL_BASE }}/preregistration/confirm?id={{ group.leader.id }}">view your badge here</a>.
 <ul>
-    <li><strong>Dealer Table Name</strong>: {{ group.name }}</li>
+    <li><strong>Marketplace Table Name</strong>: {{ group.name }}</li>
     <li><strong>Tables</strong>: {{ group.tables }} table{{ group.tables|pluralize }} (${{ group.table_cost|round(2) }}) </li>
     <li><strong>Badges</strong>: {{ group.badges }} badge{{ group.badges|pluralize }} (${{ group.badge_cost|round(2) }}) </li>
     <li><strong>Total Price</strong> ${{ group.cost }}</li>
@@ -28,6 +28,9 @@ what you plan to sell to {{ c.MARKETPLACE_EMAIL|email_only }}. If you do not pro
 waitlisted. If you frequently put your shop on vacation mode, then please include links to a gallery elsewhere. If we make 3 attempts
 to view a closed shop and are unable to see your wares, we will also automatically waitlist you.
 
+<br/><br/><strong>IMPORTANT NOTE NUMBER 2</strong>: MAGFest no longer allows proxy selling. If you have applied as a proxy seller,
+then you will be declined. We do still allow table sharing with prior email approval.
+
 <br/><br/>In the coming weeks, you'll be emailed a link to a page with instructions on booking a room. This link will not initially
 be announced publicly, it will be sent to people registered for {{ c.EVENT_NAME }} first, so keep a lookout for the e-mail in case
 it goes into your spam folder. It will go to the email address that you provide in your badge information. Receiving the link does
@@ -43,7 +46,7 @@ not approved to vend.
     {% include "preregistration/hotel_disclaimer.html" %}
 {%- endif %}
 
-<br/> <br/> <u>Dealer Rules and Information</u>
+<br/> <br/> <u>Marketplace Rules and Information</u>
 {% include "static_views/dealerRules.html" %}
 
 </body>

--- a/magprime/templates/preregistration/dealer_confirmation.html
+++ b/magprime/templates/preregistration/dealer_confirmation.html
@@ -1,0 +1,42 @@
+{% extends "./preregistration/preregbase.html" %}
+{% block title %}Marketplace Application Received{% endblock %}
+{% block backlink %}{% endblock %}
+{% block content %}
+{% include 'prereg_masthead.html' %}
+<div class="panel panel-default">
+  <div class="panel-body">
+    <h2>{% if group.status == c.WAITLISTED %}You've been added to our waitlist!{% else %}Thanks for applying to the Marketplace!{% endif %}</h2>
+
+    We've received your application for {{ group.name }} to purchase a Marketplace registration for {{ c.EVENT_NAME }}.
+
+    <br/><br/>
+    {% if group.status == c.WAITLISTED %}
+        Since the Marketplace is currently full, you've been added to our waitlist, and we'll let you know if a spot opens up for you.
+    {% else %}
+        We receive a flood of applications every year, so application processing takes a considerable amount of time.
+        Approvals will be done as promptly as possible; usually no later than <strong>two months</strong> before the event.
+    {% endif %}
+
+    <h3>What Happens Next</h3>
+    After approval, you will be emailed a link to manage your marketplace registration. From this link, you will be able to:
+    <ul>
+        <li>Pay for your marketplace registration, which includes the cost of tables and badges.</li>
+        <li>Register your Marketplace Assistants.</li>
+        <li>After your badge and table payment is received, you may add and pay for additional Marketplace Assistants.</li>
+    </ul>
+
+    Your Marketplace Payment includes your table cost and all badges in your group.  After payment, you'll be sent a link
+    by email to follow if you wish to later upgrade your badge. Your Marketplace Assistants will be able to upgrade their own
+    badges and pay for those upgrades on their own.
+
+    <br/><br/>Later, you will receive another email with more specific information about this year's event.
+
+    <br/><br/>In the event your Marketplace application is waitlisted or declined, you will receive an email. If your application
+    is not approved, you will be able to purchase badges for yourself and the number of assistants on the application
+    at the pre-registration price of ${{ c.BADGE_PRICE }} when the waitlist is exhausted. You will receive an email
+    when these badges are available for purchase.
+
+    {% include "preregistration/disclaimers.html" %}
+  </div>
+</div>
+{% endblock %}

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -55,11 +55,11 @@
         {% endif %}
 
         // Shows or hides the sweatpants option for Supporters
-        if ($.field('sweatpants')) {
+        if ($.field('sweatpants') && $.field('shirt')) {
             $('#sweatpants_size').insertAfter($.field('shirt').parents('.form-group'));
             {% if admin_area and attendee.amount_extra >= c.SUPPORTER_LEVEL %}
                 setVisible('#sweatpants_size', true);
-            {% else %}
+            {% elif not admin_area %}
                 var base_donationChanged = donationChanged;
                 donationChanged = function() {
                     base_donationChanged();


### PR DESCRIPTION
Replaces references to "Dealer" with "Marketplace" and adds an extra note about proxy selling to the app confirmation email.