### PR TITLE
Remove references to personalized badges/swadges

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -82,10 +82,12 @@
         }
         {% endif %}
 
-        // No more personalized badges -- hide the field!
-        if ($.field('badge_printed_name') && $.field('badge_printed_name').size()) {
-            $.field('badge_printed_name').parents('.form-group').remove();
-        }
+        // No more personalized swadges -- hide the field for attendees!
+        {% if attendee and attendee.badge_type not in c.PREASSIGNED_BADGE_TYPES %}
+          if ($.field('badge_printed_name') && $.field('badge_printed_name').size()) {
+              $.field('badge_printed_name').parents('.form-group').remove();
+          }
+        {% endif %}
 
     });
 </script>

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -82,6 +82,10 @@
         }
         {% endif %}
 
+        // No more personalized badges -- hide the field!
+        if ($.field('badge_printed_name') && $.field('badge_printed_name').size()) {
+            $.field('badge_printed_name').parents('.form-group').remove();
+        }
 
     });
 </script>

--- a/magprime/templates/static_views/swadge.html
+++ b/magprime/templates/static_views/swadge.html
@@ -13,8 +13,8 @@
 <h1>Swag + Badge = SWADGE</h1>
 
 <p>
-  In addition to your attendee badge, add on a custom personalized keepsake
-  swadge to accompany it. This swadge is a fully functional circuit board!
+  In addition to your attendee badge, add on a keepsake swadge to accompany it.
+  This swadge is a fully functional circuit board!
   <a href="https://www.youtube.com/watch?v=hfqV1GamDgA" target="_blank">Check out a demo of last year’s Swadge here</a>!
 </p>
 


### PR DESCRIPTION
We don't currently have plans to print personalized badges, so we're removing the badge printed name field for everyone and erroneous text on the swadge page.