### PR TITLE
Add custom deadlines for volunteer checklist emails

### DIFF
--- a/magprime/templates/emails/shifts/created.txt
+++ b/magprime/templates/emails/shifts/created.txt
@@ -1,0 +1,13 @@
+{{ attendee.first_name }},
+
+Thanks for signing up to volunteer at {{ c.EVENT_NAME }}!  You're currently assigned to the {{ attendee.assigned_depts_labels|readable_join }} department{{ attendee.assigned_depts_labels|length|pluralize }}, but let us know if you'd also like to work in any other departments.
+
+You can sign up for shifts at {{ c.URL_BASE }}/staffing/login?first_name={{ attendee.first_name|urlencode }}&last_name={{ attendee.last_name|urlencode }}&email={{ attendee.email|urlencode }}&zip_code={{ attendee.zip_code|urlencode }} -- if you need to, you can verify/update your personal information at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}. Some shifts have not been created yet - check back later for updates.
+
+You can drop shifts up until 11:59pm on December 27. After that time, you will need to contact STOPS at {{ c.STAFF_EMAIL|email_only }}.
+
+You can add shifts up until 8:00am EST on Wednesday, January 1.
+
+Please let us know if you have any questions.
+
+{{ c.STOPS_EMAIL_SIGNATURE }}

--- a/magprime/templates/emails/shifts/reminder.txt
+++ b/magprime/templates/emails/shifts/reminder.txt
@@ -1,0 +1,11 @@
+{{ attendee.first_name }},
+
+Thanks again for signing up to volunteer at {{ c.EVENT_NAME }}!  You are not currently signed up for any shifts. It is really helpful for us when our volunteers and staff sign up for shifts in advance, since that allows us to know that we might be short-staffed in some areas.
+
+Please sign up for shifts at {{ c.URL_BASE }}/staffing/login?first_name={{ attendee.first_name|urlencode }}&last_name={{ attendee.last_name|urlencode }}&email={{ attendee.email|urlencode }}&zip_code={{ attendee.zip_code|urlencode }} -- if you need to, you can verify/update your personal information at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}
+
+You can drop shifts up until 11:59pm on December 27. After that time, you will need to contact STOPS at {{ c.STAFF_EMAIL|email_only }}. You can add shifts up until 8:00am EST on Wednesday, January 1. Counts will be taken for perks by the end of December 22.
+
+Please let us know if you have any questions.
+
+{{ c.STOPS_EMAIL_SIGNATURE }}


### PR DESCRIPTION
The "drop-shift" date doesn't actually exist yet, so we need to use hard-coded text for now.