### PR TITLE
Always show volunteer agreement step

### DIFF
--- a/magprime/templates/staffing/emergency_procedures_item.html
+++ b/magprime/templates/staffing/emergency_procedures_item.html
@@ -8,8 +8,8 @@
     {% endif %}
     {% if attendee.shirt_info_marked and false %}
     <a href="emergency_procedures">our Emergency Procedures</a>
-    {%- else %}our Emergency Procedures{% endif %}
-    {%- if not attendee.reviewed_emergency_procedures -%}
+    {% else %}our Emergency Procedures{% endif %}
+    {% if not attendee.reviewed_emergency_procedures %}
     and acknowledge that you have done so
-    {%- endif -%}. (Check back on 11/11/2019 for this step!) (Deadline: December 18, 2019)
+    {% endif %}. (Check back on 11/11/2019 for this step!) (Deadline: December 18, 2019)
 </li>

--- a/magprime/templates/staffing/volunteer_agreement_item.html
+++ b/magprime/templates/staffing/volunteer_agreement_item.html
@@ -1,6 +1,6 @@
 {% import 'macros.html' as macros %}
 
-{% if c.VOLUNTEER_AGREEMENT_ENABLED and not attendee.placeholder %}
+{% if c.VOLUNTEER_AGREEMENT_ENABLED %}
     <li>
         {{ macros.checklist_image(attendee.agreed_to_volunteer_agreement) }}
         {% if not attendee.agreed_to_volunteer_agreement %}
@@ -8,6 +8,6 @@
         {% else %}
             You have agreed
         {% endif %}
-        to the terms of the <a href="volunteer_agreement">Volunteer Agreement</a>. (Deadline: November 13)
+        to the terms of the {% if not attendee.placeholder %}<a href="volunteer_agreement">Volunteer Agreement</a>{% else %}Volunteer Agreement{% endif %}. (Deadline: November 13)
     </li>
 {% endif %}


### PR DESCRIPTION
Fixes part of https://jira.magfest.net/browse/MAGDEV-706 by making the volunteer agreement step show even before someone confirms their badge.