### PR TITLE
Update 'start' date on emergency procedures

### DIFF
--- a/magprime/templates/staffing/emergency_procedures_item.html
+++ b/magprime/templates/staffing/emergency_procedures_item.html
@@ -11,5 +11,5 @@
     {% else %}our Emergency Procedures{% endif %}
     {% if not attendee.reviewed_emergency_procedures %}
     and acknowledge that you have done so
-    {% endif %}. (Check back on 11/11/2019 for this step!) (Deadline: December 18, 2019)
+    {% endif %}. (We'll let you know when this step is live!) (Deadline: December 18, 2019)
 </li>


### PR DESCRIPTION
The emergency procedures item might not be ready in time, so we're changing the text to be more vague.