### PR TITLE
Allow contractors to complete their checklist

### DIFF
--- a/magprime/automated_emails.py
+++ b/magprime/automated_emails.py
@@ -135,7 +135,7 @@ StopsEmailFixture(
 
 StopsEmailFixture(
     'Last Chance to enter your MAGFest staff shirt preferences', 'second_shirt.html',
-    lambda a: not a.shirt_info_marked,
+    lambda a: a.gets_staff_shirt and not a.shirt_info_marked,
     when=days_before(21, c.SHIRT_DEADLINE),
     ident='magprime_second_shirt')
 

--- a/magprime/templates/staffing/emergency_procedures_item.html
+++ b/magprime/templates/staffing/emergency_procedures_item.html
@@ -6,7 +6,7 @@
     {% else %}
         You have acknowledged that you reviewed our
     {% endif %}
-    {% if attendee.shirt_info_marked %}<a href="emergency_procedures">Emergency Procedures</a>{% else %}Emergency Procedures{% endif %}
-    {% if not attendee.reviewed_emergency_procedures %}and acknowledge that you have done so{% endif %}. 
+    {% if attendee.shirt_info_marked or (attendee.badge_type == c.CONTRACTOR_BADGE and attendee.food_restrictions_filled_out) %}<a href="emergency_procedures">Emergency Procedures</a>{% else %}Emergency Procedures{% endif %}
+    {% if not attendee.reviewed_emergency_procedures %} and acknowledge that you have done so{% endif %}. 
     (Deadline: December 18, 2019)
 </li>


### PR DESCRIPTION
When we removed the shirt step, we forgot to let contractors fill out the steps beyond! Also part of fixing https://jira.magfest.net/browse/MAGDEV-666.