### PR TITLE
Stop deleting declined dealers

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -99,17 +99,6 @@ class Attendee:
         return merch
 
 
-@Session.model_mixin
-class Group:
-    @presave_adjustment
-    def delete_declined(self):
-        from uber.models import Tracking
-        if self.status == c.DECLINED and not self.is_new:
-            Tracking.track(c.DELETED, self)
-            self.session.query(Group).filter_by(id=self.id).delete()
-            self.session.expunge(self)
-
-
 class SeasonPassTicket(MagModel):
     fk_id = Column(UUID)
     slug = Column(UnicodeText)


### PR DESCRIPTION
It turns out this presave adjustment was the root cause of https://jira.magfest.net/browse/MAGDEV-660. It seems the group deletion was interrupting part of the decline and convert script because it was clearing the SQLAlchemy session too soon. SQLAlchemy sessions can get very tangled very easily, so we're going to skip deleting declined dealers and just hide them via changes to the main plugin.