### PR TITLE
Don't display 'unlimited' for badges

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -65,11 +65,9 @@
             togglePrices();
         {% endif %}
 
+        {% if c.BADGES_LEFT_AT_CURRENT_PRICE and c.BADGES_LEFT_AT_CURRENT_PRICE != -1 %}
         // Show a current estimate of badges left.
-        {% if c.BADGES_LEFT_AT_CURRENT_PRICE %}
-            {% if c.BADGES_LEFT_AT_CURRENT_PRICE == -1 %}
-                {% set badges_left_text = 'Unlimited' %}
-            {% elif c.BADGES_LEFT_AT_CURRENT_PRICE <= 100 %}
+            {% if c.BADGES_LEFT_AT_CURRENT_PRICE <= 100 %}
                 {% set badges_left_text = 'Almost Gone' %}
             {% elif c.BADGES_LEFT_AT_CURRENT_PRICE <= 250 %}
                 {% set badges_left_text = 'Very Low' %}
@@ -78,8 +76,8 @@
             {% endif %}
 
             if ($('.prereg-price-notice').size()) {
-            $('#reg-types').append("<div class='help-block col-sm-9 col-sm-offset-3'>Availability of badges: <strong>{{ badges_left_text }}</strong>.</div>");
-        }
+                $('#reg-types').append("<div class='help-block col-sm-9 col-sm-offset-3'>Availability of badges: <strong>{{ badges_left_text }}</strong>.</div>");
+            }
         {% endif %}
 
         // No more personalized swadges -- hide the field for attendees!


### PR DESCRIPTION
We shouldn't said "Availability of badges" is unlimited just because we no longer use price tiers.