### PR TITLE
Add checks for minor badges selling out

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -94,9 +94,13 @@
   <div id="price_explanation">
     <div class="form-group">
       <p class="help-block col-sm-9 col-sm-offset-3">
+      {% if c.CHILD_BADGE_AVAILABLE %}
         Badges for attendees under 13 are half-price. <br/>
         Attendees under 6 enter free. <br/>
         All attendees under 13 must be accompanied by an adult with a valid Attendee badge.
+    {% else %}
+    <span class="text-danger">Unfortunately, we are sold out of badges for attendees under 18.</span>
+    {% endif %}
       </p>
     </div>
   </div>

--- a/magprime/templates/registration/index.html
+++ b/magprime/templates/registration/index.html
@@ -1,0 +1,5 @@
+{% extends "registration/index_base.html" %}
+{% block badge_counts %}
+{{ super() }}
+<button class="badge_count btn" data-warning-threshold="100" data-danger-threshold="50">{{ c.CHILD_BADGE_STOCK - c.CHILD_BADGE_COUNT }} Child badges left</button>
+{% endblock %}


### PR DESCRIPTION
We didn't actually have a check for whether there are any minor badges available, because they aren't part of the badge type dropdown and for some reason I thought that meant there wasn't anything to do. We've added a way for them to sell out, and a warning for when we're low.