### PR TITLE
Hide child badges if children can't attend

### DIFF
--- a/magprime/config.py
+++ b/magprime/config.py
@@ -22,7 +22,9 @@ class ExtraConfig:
 
     @property
     def PREREG_BADGE_TYPES(self):
-        types = [self.ATTENDEE_BADGE, self.PSEUDO_DEALER_BADGE, self.CHILD_BADGE]
+        types = [self.ATTENDEE_BADGE, self.PSEUDO_DEALER_BADGE]
+        if c.AGE_GROUP_CONFIGS[c.UNDER_13]['can_register']:
+            types.append(self.CHILD_BADGE)
         for reg_open, badge_type in [(self.BEFORE_GROUP_PREREG_TAKEDOWN, self.PSEUDO_GROUP_BADGE)]:
             if reg_open:
                 types.append(badge_type)

--- a/magprime/model_checks.py
+++ b/magprime/model_checks.py
@@ -13,12 +13,19 @@ def select_special_merch_size(attendee):
     if attendee.amount_extra >= c.SEASON_LEVEL and attendee.special_merch == c.NO_MERCH:
         return "Please select a button-down shirt size."
 
+
 @prereg_validation.Attendee
 def child_badge_over_13(attendee):
     if attendee.is_new and attendee.badge_type == c.CHILD_BADGE \
             and attendee.age_group_conf['val'] not in [c.UNDER_6, c.UNDER_13]:
         return "If you will be 13 or older at the start of {}, " \
             "please select an Attendee badge instead of a 12 and Under badge.".format(c.EVENT_NAME)
+
+
+@validation.Attendee
+def allowed_to_register(attendee):
+    if not attendee.age_group_conf['can_register']:
+        return 'Per our COVID policies, that age group currently may not register. Please check back later or email regsupport@magfest.org for more info.'
 
 
 @prereg_validation.Attendee
@@ -36,7 +43,8 @@ def child_badge_over_18(attendee):
         if c.PAGE_PATH in ['/registration/change_badge']:
             return "Attendees who are 18 or over (or will be at the start of {}) cannot have Minor badges. " \
                 "Please update their date of birth instead.".format(c.EVENT_NAME)
-                
+
+           
 @validation.Attendee
 def no_more_child_badges(attendee):
     if attendee.is_new and attendee.age_group_conf['val'] not in [c.UNDER_21, c.OVER_21, c.AGE_UNKNOWN] \

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -22,7 +22,8 @@
         // This auto-selects the Child badge when the user is, e.g., editing their registration before paying
         {% if attendee.badge_type == c.CHILD_BADGE %}
             if (window.REG_TYPES && $(REG_TYPES.row).size()) {
-                setBadge(REG_TYPES, 2);  // default to child badge when appropriate
+                {% set child_badge_index = 2 if c.GROUPS_ENABLED else 1 %}
+                setBadge(REG_TYPES, {{ child_badge_index }});  // default to child badge when appropriate
             }
         {% endif %}
 

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -1,5 +1,5 @@
 <script type="text/javascript">
-    {% if attendee.is_new and not group_id %}
+    {% if attendee.is_new and not group_id and c.CHILD_BADGE in c.PREREG_BADGE_TYPES %}
         if (window.REG_TYPES) {
             REG_TYPES.options.push({
                 title: '12 and Under: $' + Math.floor({{ c.BADGE_PRICE }} / 2),


### PR DESCRIPTION
I wrote this before realizing that we do actually need the child badge button, but it's useful to be able to hide it with config anyway.