### PR TITLE
Hide special merch field better

### DIFF
--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -138,7 +138,7 @@
     </div>
 {% endif %}
 
-<div class="form-group season-row">
+<div class="form-group season-row" style="display:none">
     <label class="col-sm-3 control-label">Button-Down Shirt Size</label>
     <div class="col-sm-6">
         <select name="special_merch" class="form-control">{{ options(c.SPECIAL_MERCH_OPTS, attendee.special_merch) }}</select>


### PR DESCRIPTION
There seem to be some cases where the season-row isn't getting hidden properly. We want that hidden ASAP, so we'll force it to start hidden.