### PR TITLE
Turn off Emergency Procedures step

### DIFF
--- a/magprime/templates/staffing/emergency_procedures_item.html
+++ b/magprime/templates/staffing/emergency_procedures_item.html
@@ -1,0 +1,7 @@
+{% import 'macros.html' as macros %}
+{% if c.EMERGENCY_PROCEDURES_ENABLED %}
+<li>
+    {{ macros.checklist_image(attendee.reviewed_emergency_procedures) }}
+    Please review our Emergency Procedures and acknowledge that you have done so. (Coming Soon!)
+</li>
+{% endif %}


### PR DESCRIPTION
We want to stop volunteers from going further than this step in their checklist, so we're manually removing the link rather than using config to remove the step entirely