### PR TITLE
Hide donate badge option for attendees who owe money

### DIFF
--- a/magprime/site_sections/magprime_reports.py
+++ b/magprime/site_sections/magprime_reports.py
@@ -68,8 +68,8 @@ class Root:
     
     @csv_file
     def donated_badge_attendees(self, out, session):
-        out.writerow(["Full Name", "Legal Name", "Email", "Phone #", "Amount Paid", "Kick-In Level",
+        out.writerow(["Full Name", "Legal Name", "Email", "Phone #", "Amount Paid", "Amount Unpaid", "Kick-In Level",
                       "Country", "Address1", "Address2", "City", "State/Region", "ZIP/Postal Code"])
         for a in session.query(Attendee).filter_by(donate_badge_cost=True).order_by('country').order_by('region'):
-            out.writerow([a.full_name, a.legal_name, a.email, a.cellphone, a.amount_paid, a.amount_extra_label,
+            out.writerow([a.full_name, a.legal_name, a.email, a.cellphone, a.amount_paid, a.amount_unpaid, a.amount_extra_label,
                           a.country, a.address1, a.address2, a.city, a.region, a.zip_code])

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -158,7 +158,7 @@
     help="Enter a group name to easily check in with other attendees in the same group.") }}
 {% endif %}
 
-{% if not attendee.checked_in %}
+{% if not attendee.checked_in and not attendee.amount_unpaid %}
 <div id="attend_virtually" class="alert alert-success">
     <div class="form-group">
         <label class="col-sm-3 control-label optional-field">Attend Virtually</label>


### PR DESCRIPTION
It's possible to select a kick-in level and then not pay for it. It doesn't make sense for us to let you ask for merch to be shipped to you in that case, so we hide the option if you aren't fully paid up.

Just in case, we'll note if an attendee has any amount of money they owe in the badge donation export.