### PR TITLE
Add shipping fee based on kick-in level

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -72,6 +72,14 @@ class Attendee:
     def checkin_bools(self):
         return ['got_merch', 'covid_ready'] if c.MERCH_AT_CHECKIN else ['covid_ready']
 
+    def calculate_shipping_fee_cost(self):
+        if self.amount_extra >= c.SEASON_LEVEL:
+                return 15
+        elif self.amount_extra >= c.SUPPORTER_LEVEL:
+            return 10
+        elif self.amount_extra >= c.SHIRT_LEVEL:
+            return 5
+
     @property
     def age_discount(self):
         # We dynamically calculate the age discount to be half the

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -158,7 +158,7 @@
     help="Enter a group name to easily check in with other attendees in the same group.") }}
 {% endif %}
 
-{% if not attendee.checked_in and not attendee.amount_unpaid %}
+{% if attendee.paid != c.NEED_NOT_PAY and not attendee.checked_in and not attendee.amount_unpaid and attendee.badge_status == c.COMPLETED_STATUS and (admin_area or c.PAGE_PATH == '/preregistration/confirm') %}
 <div id="attend_virtually" class="alert alert-success">
     <div class="form-group">
         <label class="col-sm-3 control-label optional-field">Attend Virtually</label>


### PR DESCRIPTION
Configures the merch shipping fee based on the attendee's kick-in level. Also slightly improves the logic for when to show the donate badge cost box.