### PR TITLE
Remove extra columns from Super plugin

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -18,7 +18,6 @@ class Attendee:
     special_merch = Column(Choice(c.SPECIAL_MERCH_OPTS), default=c.NO_MERCH)
     agreed_to_covid_policies = Column(Boolean, default=False)
     group_name = Column(UnicodeText)
-    covid_ready = Column(Boolean, default=False)
     donate_badge_cost = Column(Boolean, default=False)
 
     @presave_adjustment


### PR DESCRIPTION
These have been moved to the COVID plugin and the server won't start with two columns of the same name.