### PR TITLE
Fix error for special merch

### DIFF
--- a/magprime/configspec.ini
+++ b/magprime/configspec.ini
@@ -8,3 +8,6 @@ day = string(default="")
 deadline = string(default="")  # defaults to 7 days before the event
 location = string(default="")
 url = string(default="")
+
+[enums]
+[[special_merch]]


### PR DESCRIPTION
If you don't have any config for MAGPrime, it can't start because SPECIAL_MERCH_OPTS isn't defined. this fixes that.