### PR TITLE
Fix link to parental consent form

### DIFF
--- a/magprime/templates/preregistration/disclaimers.html
+++ b/magprime/templates/preregistration/disclaimers.html
@@ -32,7 +32,7 @@
   {% if c.CONSENT_FORM_URL %}
     <li>
       Attendees under 18 MUST bring a
-      <a href="http://super.magfest.org/parentalconsentform">signed parental consent form</a>,
+      <a href="http://super.magfest.org/parentalconsentform" target="_blank">signed parental consent form</a>,
       which MUST be notarized if the parent is not with the minor when the
       badge is picked up. Also, all children 12 and under will need to be
       accompanied by an adult with a paid badge.


### PR DESCRIPTION
This link was the only one that didn't open a new page, which is annoying.