### PR TITLE
Update volunteer checklist email

### DIFF
--- a/magprime/templates/emails/shifts/created.txt
+++ b/magprime/templates/emails/shifts/created.txt
@@ -4,7 +4,7 @@ Thanks for signing up to volunteer at {{ c.EVENT_NAME }}!  You're currently assi
 
 You can request staff crash space and sign up for shifts at {{ c.URL_BASE }}/staffing/login?first_name={{ attendee.first_name|urlencode }}&last_name={{ attendee.last_name|urlencode }}&email={{ attendee.email|urlencode }}&zip_code={{ attendee.zip_code|urlencode }} -- if you need to, you can verify/update your personal information at {{ c.URL_BASE }}/preregistration/confirm?id={{ attendee.id }}. Some shifts have not been created yet - check back later for updates.
 
-Shifts are not available yet, but we will email you when they are open. You can drop shifts up until 11:59pm on December 30. After that time, you will need to contact STOPS at {{ c.STAFF_EMAIL|email_only }}.
+{% if c.BEFORE_SHIFTS_CREATED %}Shifts are not available yet, but we will email you when they are open. {% endif %}You can drop shifts up until 11:59pm on December 30. After that time, you will need to contact STOPS at {{ c.STAFF_EMAIL|email_only }}.
 
 You can add shifts up until 8:00am EST on Wednesday, January 5.
 


### PR DESCRIPTION
Now, if this email is sent to anyone after shift creation, it won't say that shifts aren't live yet.