### PR TITLE
Adding fields for launch day telethon

### DIFF
--- a/magprime/models.py
+++ b/magprime/models.py
@@ -30,6 +30,7 @@ class Attendee:
     special_merch = Column(Choice(c.SPECIAL_MERCH_OPTS), default=c.NO_MERCH)
     group_name = Column(UnicodeText)
     donate_badge_cost = Column(Boolean, default=False)
+    stream_message = Column(UnicodeText)
 
     @presave_adjustment
     def set_superstar_ribbon(self):


### PR DESCRIPTION
We’re considering doing a launch day telethon, which could include pushing messages to the stream when purchasing a badge.