### PR TITLE
Hide extraneous fields in reg form

### DIFF
--- a/magprime/templates/emails/dealers/application.html
+++ b/magprime/templates/emails/dealers/application.html
@@ -23,7 +23,7 @@ We will review your request and provide you with a payment link if your applicat
 you will receive a waitlist or declined email.
 
 <br/><br/><strong>IMPORTANT NOTE</strong>: Make sure you included links to galleries, portfolios, your shop, etc in the application
-so we can adequately judge your application. These link CANNOT be for Twitter or Instagram because of the account requirements to view 
+so we can adequately judge your application. This link CANNOT be for X/Twitter or Instagram because of the account requirements to view 
 posts there. If there is no place online for us to view your product, then please email images of
 what you plan to sell to {{ c.MARKETPLACE_EMAIL|email_only }}. If you do not provide links for us to view, then you will be automatically
 declined. If you frequently put your shop on vacation mode, then please include links to a gallery elsewhere. If we make 3 attempts

--- a/magprime/templates/forms/table_info.html
+++ b/magprime/templates/forms/table_info.html
@@ -3,6 +3,7 @@
 {% block website %}
 <div class="row g-sm-3">
     <div class="col-12 col-sm-6">{{ form_macros.form_input(table_info.website) }}</div>
+    {% if not admin_area %}
     <div class="col-12 col-sm-6">
         <div class="alert alert-warning" role="alert">
             <em>
@@ -12,6 +13,7 @@
             </em>
           </div>
     </div>
+    {% endif %}
 </div>
 {% endblock %}
 

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -137,7 +137,7 @@
   </div>
 {% endif %}
 
-{% if not admin_area %}
+{% if not admin_area and False %}
 {% if c.PAGE_PATH != '/preregistration/transfer_badge' %}
   <span id="extra_donation_preselect">
     {% set superstar_dict = {0: 'No Thanks', 30: '$30', 420: '$420', 1337: '$1337', -1: 'Custom'} %}
@@ -152,6 +152,7 @@
         </div>
     </div>-->
 
+    {% if False %}
     <div class="form-group">
         <label class="col-sm-3 control-label">COVID Policy</label>
         <div class="checkbox col-sm-9">
@@ -171,6 +172,7 @@
             </label>
         </div>
     </div>
+    {% endif %}
 {% endif %}
 
 {% if c.SPECIAL_MERCH_OPTS|length > 1 %}


### PR DESCRIPTION
We're going to move these fields over, but for dealer reg we don't need them. Also updates a blurb in the application email and sets the warning about website link to not appear on admin pages.