### PR TITLE
Remove all references to COVID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,5 @@ FROM ghcr.io/magfest/ubersystem:${BRANCH}
 
 # install plugins
 COPY . plugins/magprime/
-RUN git clone --depth 1 --branch main https://github.com/magfest/covid.git plugins/covid
 
 RUN /app/env/bin/paver install_deps

--- a/magprime/models.py
+++ b/magprime/models.py
@@ -19,16 +19,6 @@ class Group:
     has_permit = Column(Boolean, default=False)
     license = Column(UnicodeText)
 
-    @presave_adjustment
-    def unagree_covid_when_approved(self):
-        if self.orig_value_of('status') != c.APPROVED and self.status == c.APPROVED:
-            for attendee in self.attendees:
-                attendee.agreed_to_covid_policies = False
-    
-    @property
-    def has_unagreed_covid_attendees(self):
-        return [attendee for attendee in self.attendees if not attendee.is_unassigned and not attendee.agreed_to_covid_policies]
-
 @Session.model_mixin
 class Attendee:
     special_merch = Column(Choice(c.SPECIAL_MERCH_OPTS), default=c.NO_MERCH)
@@ -91,7 +81,7 @@ class Attendee:
 
     @classproperty
     def searchable_bools(cls):
-        return ['placeholder', 'requested_accessibility_services', 'can_spam', 'covid_ready', 
+        return ['placeholder', 'requested_accessibility_services', 'can_spam',
                 'got_merch', 'got_staff_merch', 'confirmed', 'checked_in', 'staffing', 
                 'agreed_to_volunteer_agreement', 'reviewed_emergency_procedures', 'walk_on_volunteer', 
                 'can_work_setup', 'can_work_teardown', 'hotel_eligible', 'attractions_opt_out', 'donate_badge_cost']

--- a/magprime/templates/emails/dealers/approved.html
+++ b/magprime/templates/emails/dealers/approved.html
@@ -12,12 +12,6 @@ Payment is expected by: {{ c.DEALER_PAYMENT_DUE|datetime_local }} or your applic
     now then it will take much less time for their owners to pick them up at the festival.
     You may do this by <a href="{{ c.URL_BASE }}/preregistration/group_members?id={{ group.id }}">clicking here</a>.
 {% endif %}
-{% if group.unagreed_covid_attendees %}
-<br/> <br/> The following group members need to agree to the <a href="https://super.magfest.org/covid" target="_blank">Super MAGFest COVID policy</a>:
-<ul>
-    {% for attendee in group.unagreed_covid_attendees %}<li>{{ attendee.full_name }}</li>{% endfor %}
-</ul>
-{% endif %}
 
 <br/> <br/><strong>New Tax Information <span style="color:red">*Please Read*</span></strong>
 <p>All sellers in the Marketplace are required to obtain a Seller's Permit from the State of Maryland.
@@ -36,11 +30,6 @@ Payment is expected by: {{ c.DEALER_PAYMENT_DUE|datetime_local }} or your applic
     no later than December 12th, 2021. Check your email and/or physical mail for your sellers permit that will be 
     sent directly from MD Comptroller. ANY and ALL issues regarding receiving your permit must be directed to the 
     Comptroller's office as we, unfortunately, have no power to help!</p>
-
-<br/><strong>Covid Information <span style="color:red">*Please Read*</span></strong>
-<p>Please read the Covid Rules for MAGFest found here: <a href="https://super.magfest.org/covid" target="_blank">COVID Information — Super Magfest</a></p>
-<p>By paying for your table(s) and assigning your badge(s), you and anyone with badges associated with your table agree to abide by and follow these rules and guidelines. This is non-negotiable, and anyone who does not follow them will have their tables rescinded immediately with no refund and will have to leave. </p>
-
 
 This registration includes:
 <ul>

--- a/magprime/templates/emails/lan_room.html
+++ b/magprime/templates/emails/lan_room.html
@@ -23,7 +23,7 @@ Please update your OS and games before coming to MAGFest LAN. We try our best to
 
 <b><u>NEWS</u></b>
 <br/> <br/>
-Welcome back to MAGFest! We're excited to finally be able to see everyone again. However, due to COVID guidelines we are expecting the LAN to be less dense and are encouraging ample social distance while selecting a seat in the room.
+Welcome back to MAGFest! We're excited to finally be able to see everyone again.
 <br/> <br/>
 
 <b><u>PUBLIC COMPUTERS</u></b>

--- a/magprime/templates/emails/precon_faqs.html
+++ b/magprime/templates/emails/precon_faqs.html
@@ -35,16 +35,13 @@ Please refer to this FAQ for instructions on how to get your badge, and how to v
         <li><i>Paper schedules</i>: Printed schedules will be available in limited quantities at Registration and our Info Desk. Please consider using guidebook instead to save paper.</li>
     </ul>
 </p>
+{% if attendee.is_transferable %}
     <p>
         <b>Do you provide refunds or badge transfers?</b><br />
         We do not provide refunds, but we do allow you to sell or transfer your badge to anyone you wish.
-        {% if attendee.is_transferable %}
-            You can <a href="{{ c.URL_BASE }}/preregistration/transfer_badge?id={{ attendee.id }}" target="_blank">use this link</a> to transfer your badge.
-        {% else %}
-            E-mail <a href="mailto:regsupport@magfest.org">regsupport@magfest.org</a> with any questions about badge transfers.
-            <b>Only questions about ticket transfers, ticket confirmations, or general registration questions should be e-mailed to the registration desk e-mail address. We are unable to answer questions for any other matters sent to this address.</b>
-        {% endif %}
+        You can <a href="{{ c.URL_BASE }}/preregistration/transfer_badge?id={{ attendee.id }}" target="_blank">use this link</a> to transfer your badge.
     </p>
+{% endif %}
 <p><em>Answers to more Frequently Asked Questions can be found on <a href="https://super.magfest.org/faq/" target="_blank">our website</a>.</em></p>
 
 </body>

--- a/magprime/templates/preregistration/disclaimers.html
+++ b/magprime/templates/preregistration/disclaimers.html
@@ -2,8 +2,7 @@
 <ul>
   <li>
     All attendees (including vendors, performers, panelists, etc.) must abide by our
-    <a href="http://super.magfest.org/codeofconduct" target="_blank">code of conduct</a>{% if c.COVID_POLICIES_URL %}
-    and our <a href="http://super.magfest.org/covid" target="_blank">COVID policies</a>{% endif %}.
+    <a href="http://super.magfest.org/codeofconduct" target="_blank">code of conduct</a>.
   </li>
 
   {% if c.DEALER_REG_START and attendee and attendee.is_dealer or show_dealer_disclaimers %}

--- a/magprime/templates/regextra.html
+++ b/magprime/templates/regextra.html
@@ -66,10 +66,6 @@
               $('#tax_exempt').hide();
             }
 
-            if ($.field('agreed_to_covid_policies') && $.field('pii_consent')) {
-                $.field('agreed_to_covid_policies').parents('.form-group').insertAfter($.field('pii_consent').parents('.form-group'))
-            }
-
             $('#attend_virtually').insertBefore('#bold-field-message');
 
             /*// #tshirt_warning tells people that we don't sell 'slim' sizes at-fest
@@ -218,15 +214,6 @@
 {% endif %}
 
 {% if admin_area %}
-<div class="form-group">
-    <label for="covid_ready" class="col-sm-3 control-label optional-field">Ready to Check In</label>
-    <div class="checkbox col-sm-9">
-        <label class="checkbox-label">
-        {{ macros.checkbox(attendee, 'covid_ready') }}
-        This attendee is cleared to attend {{ c.EVENT_NAME }} under our COVID policies.
-        </label>
-    </div>
-</div>
 {% set read_only = (walk_on_ro or page_ro) or (not c.HAS_STAFFING_ADMIN_ACCESS and not c.HAS_REG_ADMIN_ACCESS) %}
 <div class="form-group staffing staffing-checked">
     <label class="col-sm-3 control-label">Walk-on Volunteer</label>


### PR DESCRIPTION
Even if we need to add similar fields back to the system, we'll want to do it in a better way with the new form system, so I'm just getting rid of it all.